### PR TITLE
[52] Have the shutdown and kill methods return a CompletableFuture wh…

### DIFF
--- a/src/main/java/org/wildfly/plugin/tools/server/ManagedServerManager.java
+++ b/src/main/java/org/wildfly/plugin/tools/server/ManagedServerManager.java
@@ -6,6 +6,7 @@
 package org.wildfly.plugin.tools.server;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -79,7 +80,7 @@ class ManagedServerManager implements ServerManager {
      * Not allowed, throws an {@link UnsupportedOperationException}
      */
     @Override
-    public void kill() {
+    public CompletableFuture<ServerManager> kill() {
         throw new UnsupportedOperationException("Cannot kill an managed server");
     }
 
@@ -106,6 +107,16 @@ class ManagedServerManager implements ServerManager {
      */
     @Override
     public void shutdown(final long timeout) throws IOException {
+        throw new UnsupportedOperationException("Cannot shutdown an managed server");
+    }
+
+    @Override
+    public CompletableFuture<ServerManager> shutdownAsync() {
+        throw new UnsupportedOperationException("Cannot shutdown an managed server");
+    }
+
+    @Override
+    public CompletableFuture<ServerManager> shutdownAsync(final long timeout) {
         throw new UnsupportedOperationException("Cannot shutdown an managed server");
     }
 
@@ -150,7 +161,7 @@ class ManagedServerManager implements ServerManager {
     @Override
     public void close() {
         if (delegate instanceof AbstractServerManager) {
-            ((AbstractServerManager<?>) delegate).internalClose(false);
+            ((AbstractServerManager<?>) delegate).internalClose(false, true);
         }
     }
 

--- a/src/main/java/org/wildfly/plugin/tools/server/StandaloneManager.java
+++ b/src/main/java/org/wildfly/plugin/tools/server/StandaloneManager.java
@@ -82,22 +82,9 @@ public class StandaloneManager extends AbstractServerManager<ModelControllerClie
     }
 
     @Override
-    public void shutdown() throws IOException {
-        shutdown(0);
-    }
-
-    @Override
-    public void shutdown(final long timeout) throws IOException {
+    void internalShutdown(final ModelControllerClient client, final long timeout) throws IOException {
         final ModelNode op = Operations.createOperation("shutdown");
         op.get("timeout").set(timeout);
-        executeOperation(op);
-        while (true) {
-            final boolean running = (process == null ? isRunning() : process.isAlive());
-            if (running) {
-                Thread.onSpinWait();
-            } else {
-                break;
-            }
-        }
+        executeOperation(client, op);
     }
 }


### PR DESCRIPTION
…ich on get() will wait for the server to shut down or the process to end.

*NOTE*: Given the backwards compatibility issue with the return types, this will fail the WildFly Arquillian testing and likely the wildfly-maven-plugin too.

resolves #52 

