### PR TITLE
[58] Migrate to using the wildfly-maven-plugin for provisioning.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,8 @@ on:
       - '**/pom.xml'
       - 'src/**'
       - '!src/test/**'
+  schedule:
+    - cron: '0 0 * * *' # Every day at 00:00 UTC
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/legacy-ci.yml
+++ b/.github/workflows/legacy-ci.yml
@@ -1,13 +1,12 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: WildFly Plugin Tools - CI
+name: WildFly Plugin Tools Legacy - CI
 
 on:
   push:
     branches-ignore:
       - 'dependabot/**'
-  pull_request:
   schedule:
     - cron: '0 0 * * *' # Every day at 00:00 UTC
 
@@ -17,30 +16,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  format-check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
-        with:
-          java-version: 11
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Validate Formatting
-        run: |
-          mvn -B validate -Pformat-check -Denforcer.skip=true
 
   build:
     name: '${{ matrix.os }}-jdk${{ matrix.java }}'
-    needs: format-check
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' , 'windows-latest',  'macos-latest' ]
+        os: [ 'ubuntu-latest' , 'windows-latest' ]
         java: ['11', '17', '21']
 
     steps:
@@ -51,8 +34,9 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
           distribution: 'temurin'
-      - name: Build and Test on ${{ matrix.os }} - ${{ matrix.java }}
-        run: mvn clean install '-Dorg.jboss.logmanager.nocolor=true'
+      - name: Build and Test on ${{ matrix.os }} - ${{ matrix.java }} with WildFly 32.0.0.Final
+        # 32.0.0.Final was the first version which deployed channels
+        run: mvn clean install '-Dorg.jboss.logmanager.nocolor=true' '-Dversion.org.wildfly=32.0.0.Final'
       - name: Upload surefire logs for failed run
         uses: actions/upload-artifact@v4
         if: failure()

--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,25 @@
         <version.org.wildfly.common.wildfly-common>1.7.0.Final</version.org.wildfly.common.wildfly-common>
         <!-- This version property is also retrieved by plugin at runtime to resolve CLI artifact -->
         <version.org.wildfly.core>25.0.0.Final</version.org.wildfly.core>
-        <version.org.wildfly>31.0.0.Final</version.org.wildfly>
+        <!-- Used to override the provisioned version of WildFly. Defaults to empty which is the latest from the channel. -->
+        <version.org.wildfly/>
 
         <!-- Test dependencies -->
         <version.org.junit>5.10.3</version.org.junit>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
 
-        <!-- galleon properties -->
+        <!-- Plugin versions -->
         <version.org.jboss.galleon>6.0.2.Final</version.org.jboss.galleon>
-        <plugin.fork.embedded>true</plugin.fork.embedded>
+        <version.wildfly-maven-plugin>5.0.0.Final</version.wildfly-maven-plugin>
+
+        <!-- Provisioning properties -->
+        <galleon.fork.embedded>true</galleon.fork.embedded>
+        <server.test.feature.pack.groupId>org.wildfly</server.test.feature.pack.groupId>
+        <server.test.feature.pack.artifactId>wildfly-ee-galleon-pack</server.test.feature.pack.artifactId>
+
+        <wildfly.channel.manifest.groupId>org.wildfly.channels</wildfly.channel.manifest.groupId>
+        <wildfly.channel.manifest.artifactId>wildfly-ee</wildfly.channel.manifest.artifactId>
+        <wildfly.channel.manifest.version>${version.org.wildfly}</wildfly.channel.manifest.version>
 
         <!-- checkstyle configuration -->
         <linkXRef>false</linkXRef>
@@ -175,27 +185,41 @@
                 <artifactId>impsort-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <version>${version.org.jboss.galleon}</version>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly-maven-plugin}</version>
                 <executions>
                     <execution>
-                        <id>provision-wildfly</id>
-                        <phase>pre-integration-test</phase>
+                        <id>server-provisioning</id>
+                        <phase>generate-test-resources</phase>
                         <goals>
                             <goal>provision</goal>
                         </goals>
                         <configuration>
+                            <provisioning-dir>${jboss.home}</provisioning-dir>
                             <feature-packs>
                                 <feature-pack>
-                                    <location>wildfly@maven(org.jboss.universe:community-universe)#${version.org.wildfly}</location>
+                                    <groupId>${server.test.feature.pack.groupId}</groupId>
+                                    <artifactId>${server.test.feature.pack.artifactId}</artifactId>
+                                    <version>${version.org.wildfly}</version>
                                 </feature-pack>
                             </feature-packs>
-                            <record-state>false</record-state>
-                            <install-dir>${project.build.directory}/wildfly</install-dir>
-                            <plugin-options>
-                                <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            <channels>
+                                <!-- If the server.version is blank the newest version of WildFly will be used.
+                                     Otherwise, be explicit.
+                                 -->
+                                <channel>
+                                    <manifest>
+                                        <groupId>${wildfly.channel.manifest.groupId}</groupId>
+                                        <artifactId>${wildfly.channel.manifest.artifactId}</artifactId>
+                                        <version>${wildfly.channel.manifest.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Include a minor update to run the CI nightly as well since we're always using the latest version of WildFly.

resolves #58 