### PR TITLE
Using argument file for classpath

### DIFF
--- a/src/main/java/org/wildfly/plugin/tools/cli/ForkedCLIUtil.java
+++ b/src/main/java/org/wildfly/plugin/tools/cli/ForkedCLIUtil.java
@@ -106,12 +106,18 @@ public class ForkedCLIUtil {
         }
         final Path properties = storeSystemProps();
 
+        // Create temp file with classpath.
+        final Path cpFile = Files.createTempFile("classpath-", ".txt");
+        Files.writeString(cpFile, cp.toString(), StandardCharsets.UTF_8);
+        LOGGER.debugf("Classpath '%s' written to argument file %s (%d chars)", cp.toString(), cpFile, cp.length());
+
         // Create the command
         final List<String> argsList = new ArrayList<>();
         argsList.add(JAVA_CMD);
         argsList.add("-server");
         argsList.add("-cp");
-        argsList.add(cp.toString());
+        // Use a Java argument file (@file notation) to avoid Windows command line length limits.
+        argsList.add("@" + cpFile);
         argsList.add(clazz.getName());
         argsList.add(home.toString());
         argsList.add(output.toString());


### PR DESCRIPTION
Windows have 32k chars command line limit. When the base path of classpath items is too long, this limit is not sufficient. I can reproduce a case where the classpath is 35k characters long.

This feature was already in Java 9 https://docs.oracle.com/javase/9/tools/java.htm#GUID-3B1CE181-CD30-4178-9602-230B800D4FAE__GUID-36C0C35E-403B-4A05-9C54-0CBE7D237C1C so it should be supported for all currently used versions.