### PR TITLE
Attempt, if the artifacts are available, to validate the stability le…

### DIFF
--- a/src/main/java/org/wildfly/plugin/tools/bootablejar/BootableJarSupport.java
+++ b/src/main/java/org/wildfly/plugin/tools/bootablejar/BootableJarSupport.java
@@ -260,6 +260,14 @@ public class BootableJarSupport {
                         jbossModules = a;
                     }
                 }
+                // Attempt to load the org.jboss.as.version module for validating the stability level if required
+                final GalleonPackageRuntime versionsPackage = fprt.getGalleonPackage("org.jboss.as.version");
+                if (versionsPackage != null) {
+                    final String artifactMapping = propsMap.get("org.wildfly.core:wildfly-version");
+                    if (artifactMapping != null) {
+                        cliArtifacts.add(parseArtifact(artifactMapping));
+                    }
+                }
             }
         }
         if (bootArtifact == null) {


### PR DESCRIPTION
…vel.

This creates a better exception if the stability level is not valid. Without this the exception looks something like:

```
[ERROR] Failed to execute goal org.wildfly.plugins:wildfly-maven-plugin:5.1.4.Final-SNAPSHOT:package (default-cli) on project helloworld-rs: CLI execution failed:Listening for transport dt_socket at address: 5005
[ERROR] SLF4J(W): No SLF4J providers were found.
[ERROR] SLF4J(W): Defaulting to no-operation (NOP) logger implementation
[ERROR] SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
[ERROR] Aug 29, 2025 9:15:44 AM org.jboss.logmanager.JBossLoggerFinder getLogger
[ERROR] ERROR: The LogManager accessed before the "java.util.logging.manager" system property was set to "org.jboss.logmanager.LogManager". Results may be unexpected.
[ERROR] java.lang.RuntimeException: Failed to generate the boot logging configuration.
[ERROR] 	at org.wildfly.plugin.tools.cli.CLIWrapper.generateBootLoggingConfig(CLIWrapper.java:264)
[ERROR] 	at org.wildfly.plugin.tools.cli.CLIForkedBootConfigGenerator.main(CLIForkedBootConfigGenerator.java:43)
[ERROR] Caused by: org.jboss.as.cli.CommandFormatException: java.util.concurrent.ExecutionException: org.jboss.as.cli.CommandFormatException: The command is not available in the current context (e.g. required subsystems or connection to the controller might be unavailable).
[ERROR] 	at org.jboss.as.cli.impl.CommandContextImpl.execute(CommandContextImpl.java:925)
[ERROR] 	at org.jboss.as.cli.impl.CommandContextImpl.handleLegacyCommand(CommandContextImpl.java:1928)
[ERROR] 	at org.jboss.as.cli.impl.CommandContextImpl.handle(CommandContextImpl.java:864)
[ERROR] 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
[ERROR] 	at org.wildfly.plugin.tools.cli.CLIWrapper.handle(CLIWrapper.java:161)
[ERROR] 	at org.wildfly.plugin.tools.cli.CLIWrapper.generateBootLoggingConfig(CLIWrapper.java:254)
[ERROR] 	... 1 more
[ERROR] 	Suppressed: org.jboss.as.cli.CommandLineException: java.util.concurrent.ExecutionException: org.jboss.as.cli.CommandLineException: Cannot start embedded server
[ERROR] 		at org.jboss.as.cli.impl.CommandContextImpl.execute(CommandContextImpl.java:927)
[ERROR] 		at org.jboss.as.cli.impl.CommandContextImpl.handleLegacyCommand(CommandContextImpl.java:1928)
[ERROR] 		at org.jboss.as.cli.impl.CommandContextImpl.handle(CommandContextImpl.java:864)
[ERROR] 		at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
[ERROR] 		at java.base/java.lang.reflect.Method.invoke(Method.java:580)
[ERROR] 		at org.wildfly.plugin.tools.cli.CLIWrapper.handle(CLIWrapper.java:161)
[ERROR] 		at org.wildfly.plugin.tools.cli.CLIWrapper.generateBootLoggingConfig(CLIWrapper.java:242)
[ERROR] 		... 1 more
[ERROR] 	Caused by: java.util.concurrent.ExecutionException: org.jboss.as.cli.CommandLineException: Cannot start embedded server
[ERROR] 		at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
[ERROR] 		at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
[ERROR] 		at org.jboss.as.cli.impl.CommandExecutor.execute(CommandExecutor.java:715)
[ERROR] 		at org.jboss.as.cli.impl.CommandExecutor.execute(CommandExecutor.java:696)
[ERROR] 		at org.jboss.as.cli.impl.CommandContextImpl.lambda$handleLegacyCommand$4(CommandContextImpl.java:1929)
[ERROR] 		at org.jboss.as.cli.impl.CommandContextImpl.execute(CommandContextImpl.java:914)
[ERROR] 		... 7 more
[ERROR] 	Caused by: org.jboss.as.cli.CommandLineException: Cannot start embedded server
[ERROR] 		at org.jboss.as.cli.embedded.EmbedServerHandler.doHandle(EmbedServerHandler.java:291)
[ERROR] 		at org.jboss.as.cli.handlers.CommandHandlerWithHelp.handle(CommandHandlerWithHelp.java:72)
[ERROR] 		at org.jboss.as.cli.impl.CommandExecutor$2.lambda$build$0(CommandExecutor.java:687)
[ERROR] 		at org.jboss.as.cli.impl.CommandExecutor.lambda$execute$0(CommandExecutor.java:710)
[ERROR] 		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[ERROR] 		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[ERROR] 		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[ERROR] 		at java.base/java.lang.Thread.run(Thread.java:1583)
[ERROR] 	Caused by: java.lang.IllegalStateException: WFLYEMB0022: Cannot invoke 'start' on embedded process
[ERROR] 		at org.wildfly.core.embedded.EmbeddedManagedProcessImpl.invokeOnServer(EmbeddedManagedProcessImpl.java:108)
[ERROR] 		at org.wildfly.core.embedded.EmbeddedManagedProcessImpl.start(EmbeddedManagedProcessImpl.java:53)
[ERROR] 		at org.jboss.as.cli.embedded.EmbedServerHandler.doHandle(EmbedServerHandler.java:233)
[ERROR] 		... 7 more
[ERROR] 	Caused by: java.lang.IllegalArgumentException: WFLYSRV0308: Failed to parse property (jboss.stability), value (invalid) should match one of: [default, community, preview, experimental]
[ERROR] 		at org.jboss.as.server@29.0.0.Final//org.jboss.as.server.ServerEnvironment.getEnumProperty(ServerEnvironment.java:1227)
[ERROR] 		at org.jboss.as.server@29.0.0.Final//org.jboss.as.server.ServerEnvironment.<init>(ServerEnvironment.java:511)
[ERROR] 		at org.jboss.as.server@29.0.0.Final//org.jboss.as.server.Main.determineEnvironment(Main.java:414)
[ERROR] 		at org.jboss.as.server@29.0.0.Final//org.jboss.as.server.embedded.StandaloneEmbeddedProcessBootstrap.bootstrapEmbeddedProcess(StandaloneEmbeddedProcessBootstrap.java:36)
[ERROR] 		at org.jboss.as.server@29.0.0.Final//org.jboss.as.server.embedded.AbstractEmbeddedProcessBootstrap.startup(AbstractEmbeddedProcessBootstrap.java:61)
[ERROR] 		at org.wildfly.embedded@29.0.0.Final//org.wildfly.core.embedded.AbstractEmbeddedManagedProcess.start(AbstractEmbeddedManagedProcess.java:66)
[ERROR] 		at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
[ERROR] 		at java.base/java.lang.reflect.Method.invoke(Method.java:580)
[ERROR] 		at org.wildfly.core.embedded.EmbeddedManagedProcessImpl.invokeOnServer(EmbeddedManagedProcessImpl.java:96)
[ERROR] 		... 9 more
[ERROR] Caused by: java.util.concurrent.ExecutionException: org.jboss.as.cli.CommandFormatException: The command is not available in the current context (e.g. required subsystems or connection to the controller might be unavailable).
[ERROR] 	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
[ERROR] 	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
[ERROR] 	at org.jboss.as.cli.impl.CommandExecutor.execute(CommandExecutor.java:715)
[ERROR] 	at org.jboss.as.cli.impl.CommandExecutor.execute(CommandExecutor.java:696)
[ERROR] 	at org.jboss.as.cli.impl.CommandContextImpl.lambda$handleLegacyCommand$4(CommandContextImpl.java:1929)
[ERROR] 	at org.jboss.as.cli.impl.CommandContextImpl.execute(CommandContextImpl.java:914)
[ERROR] 	... 7 more
[ERROR] Caused by: org.jboss.as.cli.CommandFormatException: The command is not available in the current context (e.g. required subsystems or connection to the controller might be unavailable).
[ERROR] 	at org.jboss.as.cli.handlers.CommandHandlerWithHelp.handle(CommandHandlerWithHelp.java:69)
[ERROR] 	at org.jboss.as.cli.impl.CommandExecutor$2.lambda$build$0(CommandExecutor.java:687)
[ERROR] 	at org.jboss.as.cli.impl.CommandExecutor.lambda$execute$0(CommandExecutor.java:710)
[ERROR] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[ERROR] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[ERROR] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[ERROR] 	at java.base/java.lang.Thread.run(Thread.java:1583)
```

With this change it's much shorter to something like:
```
[ERROR] Failed to execute goal org.wildfly.plugins:wildfly-maven-plugin:5.1.4.Final-SNAPSHOT:package (default-cli) on project helloworld-rs: CLI execution failed:SLF4J(W): No SLF4J providers were found.
[ERROR] SLF4J(W): Defaulting to no-operation (NOP) logger implementation
[ERROR] SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
[ERROR] java.lang.IllegalArgumentException: Invalid stability level of invalid. Allowed levels are: [default, community, preview, experimental]
[ERROR] 	at org.wildfly.plugin.tools.cli.CLIWrapper.<init>(CLIWrapper.java:133)
[ERROR] 	at org.wildfly.plugin.tools.cli.CLIForkedBootConfigGenerator.main(CLIForkedBootConfigGenerator.java:40)
```
